### PR TITLE
feat: add MiniMax as cloud LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,18 @@ First, you should set up a virtual Python environment. You have several options 
 - **openai-whisper**: A robust tool for speech-to-text conversion.
 - **chatterbox-tts**: State-of-the-art text-to-speech synthesis with voice cloning and emotion control.
 - **langchain**: A straightforward library for interfacing with Large Language Models (LLMs).
+- **langchain-openai**: For connecting to OpenAI-compatible cloud LLM providers like [MiniMax](https://www.minimaxi.com).
 - **sounddevice**, **pyaudio**, and **speechrecognition**: Essential for audio recording and playback.
 
 For a detailed list of dependencies, refer to the link here.
 
-The most critical component here is the Large Language Model (LLM) backend, for which we will use Ollama. Ollama is widely recognized as a popular tool for running and serving LLMs offline. If Ollama is new to you, I recommend checking out my previous article on offline RAG: "Build Your Own RAG and Run It Locally: Langchain + Ollama + Streamlit". Basically, you just need to download the Ollama application, pull your preferred model, and run it.
+The most critical component here is the Large Language Model (LLM) backend. By default, we use **Ollama** for running LLMs locally. Alternatively, you can use **MiniMax** as a cloud LLM provider for higher-quality responses without local GPU requirements. If Ollama is new to you, I recommend checking out my previous article on offline RAG: "Build Your Own RAG and Run It Locally: Langchain + Ollama + Streamlit". Basically, you just need to download the Ollama application, pull your preferred model, and run it.
 
 ### Architecture
 Okay, if everything has been set up, let's proceed to the next step. Below is the overall architecture of our application, which fundamentally comprises 3 main components:
 
 - **Speech Recognition**: Utilizing OpenAI's Whisper, we convert spoken language into text. Whisper's training on diverse datasets ensures its proficiency across various languages and dialects.
-- **Conversational Chain**: For the conversational capabilities, we'll employ the Langchain interface for the Llama-2 model (or any other model), which is served using Ollama. This setup promises a seamless and engaging conversational flow.
+- **Conversational Chain**: For the conversational capabilities, we'll employ the Langchain interface with a pluggable LLM backend — either a local model via Ollama (e.g., Gemma3, Llama-4) or a cloud model via [MiniMax](https://www.minimaxi.com) (MiniMax-M2.7). This setup promises a seamless and engaging conversational flow.
 - **Speech Synthesizer**: The transformation of text to speech is achieved through Chatterbox TTS, a state-of-the-art model from Resemble AI, renowned for its lifelike speech production and voice cloning capabilities.
 
 The workflow is straightforward: record speech, transcribe to text, generate a response using an LLM, and vocalize the response using ChatterBox.
@@ -43,7 +44,7 @@ The workflow is straightforward: record speech, transcribe to text, generate a r
 flowchart TD
     A[🎤 User Speech Input] --> B[Speech Recognition<br/>OpenAI Whisper]
     B --> C[📝 Text Transcription]
-    C --> D[Conversational Chain<br/>Langchain + Ollama<br/>Gemma3 / Llama-4 / Other LLMs]
+    C --> D[Conversational Chain<br/>Langchain + Ollama / MiniMax<br/>Gemma3 / Llama-4 / MiniMax-M2.7]
     D --> E[🤖 Generated Response]
     E --> F[Speech Synthesizer<br/>Chatterbox TTS]
     F --> G[🔊 Audio Output]
@@ -113,6 +114,18 @@ python -c "import nltk; nltk.download('punkt')"
 ollama pull gemma3  # or any other model you prefer
 ```
 
+#### Setup MiniMax (Cloud LLM Alternative)
+
+If you don't have a local GPU or prefer higher-quality cloud models, you can use [MiniMax](https://www.minimaxi.com) as the LLM backend:
+
+1. Sign up at [MiniMax Platform](https://www.minimaxi.com) and get your API key
+2. Set the environment variable:
+   ```bash
+   export MINIMAX_API_KEY="your-api-key-here"
+   ```
+
+No Ollama installation is needed when using MiniMax — the LLM runs in the cloud while TTS and STT still run locally.
+
 ### Usage
 
 #### Basic Usage
@@ -138,8 +151,26 @@ python app.py --model codellama
 python app.py --save-voice
 ```
 
+#### With MiniMax Cloud LLM
+```bash
+# Use MiniMax as the LLM provider (requires MINIMAX_API_KEY env var)
+python app.py --provider minimax
+
+# Use a specific MiniMax model with custom temperature
+python app.py --provider minimax --model MiniMax-M2.7 --temperature 0.8
+
+# Pass API key directly
+python app.py --provider minimax --api-key your-api-key-here
+
+# Combine with voice cloning and emotion control
+python app.py --provider minimax --voice path/to/voice.wav --exaggeration 0.7
+```
+
 ### Configuration Options
 
+- `--provider`: LLM provider (`ollama` or `minimax`, default: ollama)
+- `--api-key`: API key for cloud LLM providers (or use `MINIMAX_API_KEY` env var)
+- `--temperature`: LLM temperature (0.0-1.0, default: 0.7)
 - `--voice`: Path to audio file for voice cloning
 - `--exaggeration`: Emotion intensity (0.0-1.0, default: 0.5)
   - Lower values (0.3-0.4): Calmer, more neutral delivery
@@ -281,6 +312,7 @@ The combination of Whisper's robust speech recognition, Ollama's flexible LLM se
 
 - [ChatterBox GitHub](https://github.com/resemble-ai/chatterbox)
 - [Ollama](https://ollama.ai)
+- [MiniMax Platform](https://www.minimaxi.com)
 - [Whisper](https://github.com/openai/whisper)
 - [Original Blog Post](https://blog.duy-huynh.com/build-your-own-voice-assistant-and-run-it-locally/)
 

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from queue import Queue
 from rich.console import Console
 # Updated imports for modern LangChain
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_ollama import OllamaLLM
@@ -22,12 +23,53 @@ parser = argparse.ArgumentParser(description="Local Voice Assistant with Chatter
 parser.add_argument("--voice", type=str, help="Path to voice sample for cloning")
 parser.add_argument("--exaggeration", type=float, default=0.5, help="Emotion exaggeration (0.0-1.0)")
 parser.add_argument("--cfg-weight", type=float, default=0.5, help="CFG weight for pacing (0.0-1.0)")
-parser.add_argument("--model", type=str, default="gemma3", help="Ollama model to use")
+parser.add_argument("--model", type=str, default=None, help="LLM model name (default: gemma3 for ollama, MiniMax-M2.7 for minimax)")
+parser.add_argument("--provider", type=str, default="ollama", choices=["ollama", "minimax"],
+                    help="LLM provider: 'ollama' for local models, 'minimax' for MiniMax cloud API (default: ollama)")
+parser.add_argument("--api-key", type=str, default=None, help="API key for cloud LLM providers (or set MINIMAX_API_KEY env var)")
+parser.add_argument("--temperature", type=float, default=0.7, help="LLM temperature (default: 0.7)")
 parser.add_argument("--save-voice", action="store_true", help="Save generated voice samples")
 args = parser.parse_args()
 
 # Initialize TTS with ChatterBox
 tts = TextToSpeechService()
+
+
+def create_llm(provider: str, model: str | None = None, api_key: str | None = None, temperature: float = 0.7):
+    """
+    Create an LLM instance based on the selected provider.
+
+    Args:
+        provider: LLM provider name ('ollama' or 'minimax').
+        model: Model name. Defaults to 'gemma3' for ollama, 'MiniMax-M2.7' for minimax.
+        api_key: API key for cloud providers (or set MINIMAX_API_KEY env var).
+        temperature: LLM temperature (default: 0.7).
+
+    Returns:
+        A LangChain LLM or ChatModel instance.
+    """
+    if provider == "ollama":
+        return OllamaLLM(model=model or "gemma3", base_url="http://localhost:11434")
+    elif provider == "minimax":
+        from langchain_openai import ChatOpenAI
+
+        resolved_key = api_key or os.environ.get("MINIMAX_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "MiniMax API key is required. Set the MINIMAX_API_KEY environment "
+                "variable or pass --api-key on the command line."
+            )
+        # MiniMax temperature must be in (0.0, 1.0]
+        clamped_temperature = max(0.01, min(1.0, temperature))
+        return ChatOpenAI(
+            model=model or "MiniMax-M2.7",
+            base_url="https://api.minimax.io/v1",
+            api_key=resolved_key,
+            temperature=clamped_temperature,
+        )
+    else:
+        raise ValueError(f"Unknown provider: {provider}. Supported: ollama, minimax")
+
 
 # Modern prompt template using ChatPromptTemplate
 prompt_template = ChatPromptTemplate.from_messages([
@@ -36,11 +78,17 @@ prompt_template = ChatPromptTemplate.from_messages([
     ("human", "{input}")
 ])
 
-# Initialize LLM
-llm = OllamaLLM(model=args.model, base_url="http://localhost:11434")
+# Initialize LLM via provider factory
+llm = create_llm(
+    provider=args.provider,
+    model=args.model,
+    api_key=args.api_key,
+    temperature=args.temperature,
+)
 
 # Create the chain with modern LCEL syntax
-chain = prompt_template | llm
+# StrOutputParser normalizes output across providers (string from Ollama, AIMessage from ChatOpenAI)
+chain = prompt_template | llm | StrOutputParser()
 
 # Chat history storage
 chat_sessions = {}
@@ -166,7 +214,8 @@ if __name__ == "__main__":
 
     console.print(f"[blue]Emotion exaggeration: {args.exaggeration}")
     console.print(f"[blue]CFG weight: {args.cfg_weight}")
-    console.print(f"[blue]LLM model: {args.model}")
+    console.print(f"[blue]LLM model: {args.model or ('gemma3' if args.provider == 'ollama' else 'MiniMax-M2.7')}")
+    console.print(f"[blue]LLM provider: {args.provider}")
     console.print("[cyan]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     console.print("[cyan]Press Ctrl+C to exit.\n")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "chatterbox-tts>=0.1.1",
     "langchain-ollama>=0.3.3",
+    "langchain-openai>=0.3.0",
     "langchain>=0.3.25",
     "nltk>=3.9.1",
     "openai-whisper>=20240930",

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,206 @@
+"""Unit tests for the LLM provider factory in app.py."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add parent directory to path so we can import create_llm
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestCreateLlm(unittest.TestCase):
+    """Tests for the create_llm() factory function."""
+
+    def _import_create_llm(self):
+        """Import create_llm with heavy dependencies mocked out."""
+        # Mock heavy imports that aren't needed for testing the factory logic
+        mock_nltk = MagicMock()
+        mock_nltk.__spec__ = MagicMock()  # transformers checks __spec__ to detect nltk
+
+        mock_modules = {
+            "whisper": MagicMock(),
+            "sounddevice": MagicMock(),
+            "numpy": MagicMock(),
+            "torch": MagicMock(),
+            "torchaudio": MagicMock(),
+            "nltk": mock_nltk,
+            "chatterbox": MagicMock(),
+            "chatterbox.tts": MagicMock(),
+            "tts": MagicMock(),
+        }
+        with patch.dict("sys.modules", mock_modules):
+            # Prevent argparse from parsing test runner args
+            with patch("sys.argv", ["app.py"]):
+                # Re-import to get the create_llm function
+                if "app" in sys.modules:
+                    del sys.modules["app"]
+                from app import create_llm
+        return create_llm
+
+    @patch("langchain_ollama.OllamaLLM")
+    def test_ollama_provider_default_model(self, mock_ollama):
+        """Test that Ollama provider uses default model 'gemma3'."""
+        create_llm = self._import_create_llm()
+        mock_ollama.reset_mock()  # Clear calls from module-level initialization
+        create_llm("ollama")
+        mock_ollama.assert_called_once_with(model="gemma3", base_url="http://localhost:11434")
+
+    @patch("langchain_ollama.OllamaLLM")
+    def test_ollama_provider_custom_model(self, mock_ollama):
+        """Test that Ollama provider accepts a custom model name."""
+        create_llm = self._import_create_llm()
+        mock_ollama.reset_mock()  # Clear calls from module-level initialization
+        create_llm("ollama", model="llama3")
+        mock_ollama.assert_called_once_with(model="llama3", base_url="http://localhost:11434")
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_provider_default_model(self, mock_chat):
+        """Test that MiniMax provider uses default model 'MiniMax-M2.7'."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key")
+        mock_chat.assert_called_once_with(
+            model="MiniMax-M2.7",
+            base_url="https://api.minimax.io/v1",
+            api_key="test-key",
+            temperature=0.7,
+        )
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_provider_custom_model(self, mock_chat):
+        """Test that MiniMax provider accepts a custom model name."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", model="MiniMax-M2.7-highspeed", api_key="test-key")
+        mock_chat.assert_called_once_with(
+            model="MiniMax-M2.7-highspeed",
+            base_url="https://api.minimax.io/v1",
+            api_key="test-key",
+            temperature=0.7,
+        )
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_api_key_from_env(self, mock_chat):
+        """Test that MiniMax provider reads API key from MINIMAX_API_KEY env var."""
+        create_llm = self._import_create_llm()
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
+            create_llm("minimax")
+        mock_chat.assert_called_once_with(
+            model="MiniMax-M2.7",
+            base_url="https://api.minimax.io/v1",
+            api_key="env-key",
+            temperature=0.7,
+        )
+
+    def test_minimax_no_api_key_raises(self):
+        """Test that MiniMax provider raises ValueError when no API key is provided."""
+        create_llm = self._import_create_llm()
+        with patch.dict(os.environ, {}, clear=True):
+            # Ensure MINIMAX_API_KEY is not set
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with self.assertRaises(ValueError) as ctx:
+                create_llm("minimax")
+            self.assertIn("MINIMAX_API_KEY", str(ctx.exception))
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_temperature_clamping_zero(self, mock_chat):
+        """Test that temperature 0.0 is clamped to 0.01 for MiniMax."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key", temperature=0.0)
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.01)
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_temperature_clamping_negative(self, mock_chat):
+        """Test that negative temperature is clamped to 0.01 for MiniMax."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key", temperature=-0.5)
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.01)
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_temperature_clamping_high(self, mock_chat):
+        """Test that temperature > 1.0 is clamped to 1.0 for MiniMax."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key", temperature=2.0)
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs["temperature"], 1.0)
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_temperature_normal(self, mock_chat):
+        """Test that a valid temperature is passed through unchanged."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key", temperature=0.5)
+        call_kwargs = mock_chat.call_args[1]
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.5)
+
+    def test_unknown_provider_raises(self):
+        """Test that an unknown provider raises ValueError."""
+        create_llm = self._import_create_llm()
+        with self.assertRaises(ValueError) as ctx:
+            create_llm("unknown_provider")
+        self.assertIn("Unknown provider", str(ctx.exception))
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_api_key_arg_overrides_env(self, mock_chat):
+        """Test that explicit api_key argument takes precedence over env var."""
+        create_llm = self._import_create_llm()
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}):
+            create_llm("minimax", api_key="arg-key")
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["api_key"], "arg-key")
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_base_url(self, mock_chat):
+        """Test that MiniMax provider uses the correct base URL."""
+        create_llm = self._import_create_llm()
+        create_llm("minimax", api_key="test-key")
+        call_kwargs = mock_chat.call_args[1]
+        self.assertEqual(call_kwargs["base_url"], "https://api.minimax.io/v1")
+
+
+class TestAnalyzeEmotion(unittest.TestCase):
+    """Tests for the analyze_emotion() helper function."""
+
+    def _import_analyze_emotion(self):
+        mock_modules = {
+            "whisper": MagicMock(),
+            "sounddevice": MagicMock(),
+            "numpy": MagicMock(),
+            "torch": MagicMock(),
+            "torchaudio": MagicMock(),
+            "nltk": MagicMock(),
+            "chatterbox": MagicMock(),
+            "chatterbox.tts": MagicMock(),
+            "tts": MagicMock(),
+        }
+        with patch.dict("sys.modules", mock_modules):
+            with patch("sys.argv", ["app.py"]):
+                if "app" in sys.modules:
+                    del sys.modules["app"]
+                from app import analyze_emotion
+        return analyze_emotion
+
+    def test_neutral_text(self):
+        analyze_emotion = self._import_analyze_emotion()
+        score = analyze_emotion("The weather is nice today.")
+        self.assertAlmostEqual(score, 0.5)
+
+    def test_emotional_text(self):
+        analyze_emotion = self._import_analyze_emotion()
+        score = analyze_emotion("This is amazing! I love it!")
+        self.assertGreater(score, 0.5)
+
+    def test_score_capped_at_max(self):
+        analyze_emotion = self._import_analyze_emotion()
+        # Text with many emotional keywords
+        score = analyze_emotion("amazing terrible love hate excited sad happy angry wonderful awful !")
+        self.assertLessEqual(score, 0.9)
+
+    def test_score_has_minimum(self):
+        analyze_emotion = self._import_analyze_emotion()
+        score = analyze_emotion("ok")
+        self.assertGreaterEqual(score, 0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,88 @@
+"""Integration tests for MiniMax LLM provider.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+They are skipped automatically if the key is not set.
+"""
+
+import os
+import sys
+import unittest
+
+# Add parent directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY")
+SKIP_REASON = "MINIMAX_API_KEY not set — skipping MiniMax integration tests"
+
+
+@unittest.skipUnless(MINIMAX_API_KEY, SKIP_REASON)
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    def _import_create_llm(self):
+        from unittest.mock import patch, MagicMock
+
+        mock_nltk = MagicMock()
+        mock_nltk.__spec__ = MagicMock()  # transformers checks __spec__ to detect nltk
+
+        mock_modules = {
+            "whisper": MagicMock(),
+            "sounddevice": MagicMock(),
+            "numpy": MagicMock(),
+            "torch": MagicMock(),
+            "torchaudio": MagicMock(),
+            "nltk": mock_nltk,
+            "chatterbox": MagicMock(),
+            "chatterbox.tts": MagicMock(),
+            "tts": MagicMock(),
+        }
+        with patch.dict("sys.modules", mock_modules):
+            with patch("sys.argv", ["app.py"]):
+                if "app" in sys.modules:
+                    del sys.modules["app"]
+                from app import create_llm
+        return create_llm
+
+    def test_minimax_basic_response(self):
+        """Test that MiniMax returns a valid response to a simple prompt."""
+        create_llm = self._import_create_llm()
+        llm = create_llm("minimax", api_key=MINIMAX_API_KEY, temperature=0.7)
+        response = llm.invoke("Say hello in exactly three words.")
+        # ChatOpenAI returns an AIMessage
+        content = response.content if hasattr(response, "content") else str(response)
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content.strip()), 0)
+
+    def test_minimax_m27_highspeed(self):
+        """Test that MiniMax-M2.7-highspeed model works."""
+        create_llm = self._import_create_llm()
+        llm = create_llm(
+            "minimax",
+            model="MiniMax-M2.7-highspeed",
+            api_key=MINIMAX_API_KEY,
+            temperature=0.5,
+        )
+        response = llm.invoke("What is 2+2? Answer with just the number.")
+        content = response.content if hasattr(response, "content") else str(response)
+        self.assertIn("4", content)
+
+    def test_minimax_with_langchain_chain(self):
+        """Test MiniMax works in a LangChain LCEL chain with StrOutputParser."""
+        from langchain_core.prompts import ChatPromptTemplate
+        from langchain_core.output_parsers import StrOutputParser
+
+        create_llm = self._import_create_llm()
+        llm = create_llm("minimax", api_key=MINIMAX_API_KEY, temperature=0.5)
+
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", "You are a helpful assistant. Reply in one sentence."),
+            ("human", "{input}"),
+        ])
+        chain = prompt | llm | StrOutputParser()
+        result = chain.invoke({"input": "What color is the sky?"})
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result.strip()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add [MiniMax](https://www.minimaxi.com) as an alternative cloud LLM provider alongside the existing local Ollama backend
- Introduce a `create_llm()` factory function with `--provider` CLI arg to switch between `ollama` (local) and `minimax` (cloud)
- Add `StrOutputParser` to the LangChain chain to normalize output across LLM and ChatModel providers
- Add `--api-key` and `--temperature` CLI options for cloud provider configuration

## Motivation

The project currently only supports local LLM inference via Ollama, requiring users to have a GPU for reasonable performance. Adding MiniMax as a cloud LLM provider option means users without GPUs can still use high-quality language models while keeping TTS and STT running locally. The README Scaling to Production section already listed Integration with more LLM providers as a future enhancement.

## Changes

| File | Change |
|------|--------|
| `app.py` | `create_llm()` factory, `--provider`/`--api-key`/`--temperature` CLI args, `StrOutputParser` for output normalization |
| `pyproject.toml` | Add `langchain-openai>=0.3.0` dependency |
| `README.md` | MiniMax setup guide, usage examples, architecture diagram update, config docs |
| `tests/test_llm_provider.py` | 17 unit tests (factory, temp clamping, API key resolution, emotion analysis) |
| `tests/test_minimax_integration.py` | 3 integration tests (basic response, M2.7-highspeed model, LangChain chain) |

## Usage

```bash
# Default: local Ollama (existing behavior unchanged)
python app.py

# Cloud: MiniMax M2.7 (204K context)
export MINIMAX_API_KEY="your-key"
python app.py --provider minimax

# With custom model and temperature
python app.py --provider minimax --model MiniMax-M2.7-highspeed --temperature 0.8
```

## Test plan

- [x] 17 unit tests pass (provider factory, temperature clamping, API key resolution, emotion analysis)
- [x] 3 integration tests pass against live MiniMax API
- [ ] Verify `python app.py` still works with Ollama (default, no breaking changes)
- [ ] Verify `python app.py --provider minimax` with a valid API key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as an alternative LLM backend alongside Ollama
  * New configuration options for provider selection, API authentication, and temperature adjustment

* **Documentation**
  * Updated README with MiniMax setup instructions and new usage examples

* **Tests**
  * Added comprehensive test coverage for the new LLM provider functionality

* **Chores**
  * Added new dependency for MiniMax provider support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->